### PR TITLE
Provide events list and fix bugs

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,9 @@ app.post('/my/events',
 app.get('/events/create',
   events.create
 );
+app.get('/events',
+  events.list
+);
 app.post('/events',
   events.dateify,
   events.collect,

--- a/app.js
+++ b/app.js
@@ -47,9 +47,7 @@ hbs.registerHelper('date', function (format, date) {
 // Routes
 
 app.get('/',
-  events.collect,
   events.listUpcoming,
-  events.markup,
   routes.index
 );
 app.post('/login',
@@ -57,7 +55,7 @@ app.post('/login',
 );
 app.post('/my/events',
   users.findOne,
-  events.retrieve,
+  events.findOne,
   events.update
 );
 app.get('/events/create',

--- a/routes/events.js
+++ b/routes/events.js
@@ -12,7 +12,7 @@ exports.collect = function (req, res, next) {
   });
 };
 
-exports.findOne = function (req, res, next) {
+exports.get = function (req, res, next) {
   req.events.findOne(req.body, function (error, event) {
     if (error) { return new Error(error); }
     req.event = event;
@@ -20,7 +20,12 @@ exports.findOne = function (req, res, next) {
   });
 };
 
-exports.listUpcoming = function (req, res, next) {
+exports.uncollect = function (req, res, next) {
+  req.events = undefined;
+  next();
+};
+
+exports.findUpcoming = function (req, res, next) {
   req.events
     .find({ starts_at: { $gt: new Date() }})
     .sort({ starts_at: 1 })
@@ -50,9 +55,16 @@ exports.markup = function (req, res, next) {
  * Bundles
  */
 
-exports.retrieve = [
+exports.listUpcoming = [
   exports.collect,
-  exports.findOne
+  exports.findUpcoming,
+  exports.markup,
+  exports.uncollect
+];
+
+exports.findOne = [
+  exports.collect,
+  exports.get
 ];
 
 /*

--- a/routes/events.js
+++ b/routes/events.js
@@ -67,6 +67,12 @@ exports.findOne = [
   exports.get
 ];
 
+exports.list = [
+  events.collect,
+  events.markup,
+  events.index
+];
+
 /*
  * Endware
  */
@@ -86,5 +92,14 @@ exports.update = function (req, res) {
   req.events.findAndModify(req.event, [], { $set: req.body }, {}, function (error, event) {
     if (error) { throw new Error(error); }
     else { res.send(event); }
+  });
+};
+
+exports.index = function (req, res) {
+  req.events.find().toArray(function (error, found) {
+    res.render('events', {
+        title: 'Events',
+        events: found
+    });
   });
 };

--- a/views/events.hbs
+++ b/views/events.hbs
@@ -1,0 +1,27 @@
+<section>
+{{#if events.length}}
+  {{#each events}}
+  <article>
+    <header>
+      <hgroup>
+        <h2>{{title}}</h2>
+        <h3>{{date "dddd, MMM Do, \at h:mma" starts_at}}</h3>
+        {{#if location}}
+        <h4>@ <a href="{{location.url}}">{{location.name}}</a></h4>
+        {{/if}}
+      </hgroup>
+    </header>
+    <div>{{{description}}}</div>
+    <aside>
+      <a href="/events/edit/{{_id}}">Edit</a>
+      <form method="post" action="/events/{{_id}}">
+        <input type="hidden" name="_method" value="delete">
+        <input type="submit" value="Delete">
+      </form>
+    </aside>
+  </article>
+  {{/each}}
+{{else}}
+  <h2>No upcoming events</h2>
+{{/if}}
+</section>

--- a/views/users.hbs
+++ b/views/users.hbs
@@ -3,10 +3,10 @@
     <th>Name</th>
     <th>Created At</th>
   </tr>
+  {{#each users}}
   <tr>
-    {{#each users}}
     <td>{{name}}</td>
     <td>{{date "MMM Do, YYYY h:mm a" created_at}}</td>
-    {{/each}}
   </tr>
+  {{/each}}
 </table>


### PR DESCRIPTION
App now can access the complete list of events, expired and upcoming, at `/events`. Each event has an edit link and a delete button, but they aren't finished. We'll need to get the routes set up to get them to work.

I also did a tiny bit of refactoring and fixed a bug in the users template.
