### PR TITLE
Migrate to Express version 3

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@
  */
 
 var express = require('express')
+  , http = require('http')
+  , path = require('path')
   , mongo = require('mongodb')
   , hbs = require('hbs')
   , moment = require('moment')
@@ -12,7 +14,7 @@ var express = require('express')
   , events = require('./routes/events')
   , auth = require('./lib/auth');
 
-var app = module.exports = express.createServer();
+var app = express();
 
 app.configure(function () {
   var db = mongo.Db('test', mongo.Server('localhost', 27017, {}), {});
@@ -32,8 +34,11 @@ app.configure('development', function () {
 
 // Configuration
 app.configure(function () {
+  app.set('port', process.env.PORT || 3000);
   app.set('views', __dirname + '/views');
   app.set('view engine', 'hbs');
+  app.use(express.favicon());
+  app.use(express.logger('dev'));
   app.use(express.bodyParser());
   app.use(express.methodOverride());
   app.use(express.cookieParser());
@@ -44,10 +49,6 @@ app.configure(function () {
 });
 
 app.configure('development', function () {
-  app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-});
-
-app.configure('production', function () {
   app.use(express.errorHandler());
 });
 
@@ -87,6 +88,6 @@ app.post('/events',
   events.save
 );
 
-app.listen(3000, function () {
-  console.log("Express server listening on port %d in %s mode", app.address().port, app.settings.env);
+http.createServer(app).listen(app.get('port'), function () {
+  console.log("Express server listening on port " + app.get('port'));
 });

--- a/app.js
+++ b/app.js
@@ -59,17 +59,8 @@ hbs.registerHelper('date', function (format, date) {
 // Routes
 
 app.get('/',
-  function (req, res, next) {
-    console.log(req.session);
-    next();
-  },
   events.listUpcoming,
   routes.index
-);
-app.all('/auth/github/callback',
-  function (request, response) {
-    console.log("Got here");
-  }
 );
 app.post('/my/events',
   users.findOne,

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "meetdownjs"
-  , "version": "0.1.0"
-  , "private": true
-  , "dependencies": {
-      "express": "~3.0.0rc4"
-    , "mongodb": "~0.9.6-7"
-    , "hbs": "~1.0.2"
-    , "moment": "~1.6.0"
-    , "github-flavored-markdown": "~1.0.1"
-    , "everyauth": "~0.3.0"
+  "name": "meetdownjs",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "express": "~3.0.0rc4",
+    "mongodb": "~0.9.6-7",
+    "hbs": "~1.0.2",
+    "moment": "~1.6.0",
+    "github-flavored-markdown": "~1.0.1",
+    "everyauth": "~0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   , "private": true
   , "dependencies": {
       "express": "2.5.8"
-    , "mongodb": ">= 0.9.6-7"
-    , "hbs": ">= 1.0.2"
-    , "moment": ">= 1.6.0"
-    , "github-flavored-markdown": ">= 1.0.1"
-    , "everyauth": "0.3.0"
+    , "mongodb": "~0.9.6-7"
+    , "hbs": "~1.0.2"
+    , "moment": "~1.6.0"
+    , "github-flavored-markdown": "~1.0.1"
+    , "everyauth": "~0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   , "version": "0.1.0"
   , "private": true
   , "dependencies": {
-      "express": "2.5.8"
+      "express": "~3.0.0rc4"
     , "mongodb": "~0.9.6-7"
     , "hbs": "~1.0.2"
     , "moment": "~1.6.0"


### PR DESCRIPTION
These commits:
- Migrate to express 3.0.0rc4
- Removes stray debug code
- Uses a more conservative dependency config
